### PR TITLE
Varnish 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM debian:stretch
+MAINTAINER sysadmin@mysociety.org
+ENV DEBIAN_FRONTEND noninteractive
+ENV VARNISHAPI_VMODDIR=/usr/lib/x86_64-linux-gnu/varnish/vmods/
+RUN apt-get update -q && apt-get install -y -qq \
+      autotools-dev \
+      automake \
+      devscripts \
+      libtool \
+      python-docutils \
+      pkg-config \
+      libpcre3-dev \
+      libeditline-dev \
+      libedit-dev \
+      make \
+      dpkg-dev \
+      git \
+      libjemalloc-dev \
+      libev-dev \
+      libncurses-dev \
+      python-sphinx \
+      graphviz \
+      varnish \
+      libvarnishapi-dev \
+      libhiredis-dev \
+      redis-server \
+      supervisor
+
+RUN mkdir /home/builder
+WORKDIR /home/builder
+
+RUN git clone https://github.com/xcir/vtctrans.git \
+      && git clone https://github.com/sagepe/libvmod-redis.git \
+      && cd libvmod-redis \
+      && git checkout origin/stretch \
+      && ./autogen.sh \
+      && ./configure --libdir=/usr/lib/x86_64-linux-gnu \
+      && make \
+      && make install
+
+COPY ./docker/redis.conf /etc/redis/redis.conf
+COPY ./docker/supervisor /etc/supervisor/conf.d
+
+EXPOSE 81
+CMD ["/usr/bin/supervisord", "--nodaemon"]

--- a/docker/redis.conf
+++ b/docker/redis.conf
@@ -1,0 +1,1 @@
+daemonize no

--- a/docker/supervisor/redis.conf
+++ b/docker/supervisor/redis.conf
@@ -1,0 +1,9 @@
+[program:redis-server]
+command=redis-server
+autostart=true
+autorestart=true
+user=root
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/supervisor/varnish.conf
+++ b/docker/supervisor/varnish.conf
@@ -1,0 +1,9 @@
+[program:varnishd]
+command=varnishd -a :81 -f /home/builder/varnish-apikey/example/example.vcl -s malloc,256m -n example -F
+autostart=true
+autorestart=true
+user=root
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/script/build
+++ b/script/build
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# build: build some docker images
+#
+
+set -e 
+
+cd "$(dirname "$0")/.."
+
+for image in server test ; do
+  echo "==> Building ${image} image..."
+  docker-compose -f ${image}.yml build
+done

--- a/script/console
+++ b/script/console
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# console: attach to server console
+#
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Checking server status..."
+script/server
+sleep 2
+
+if [ "$1" == "--docker" ]; then
+  docker logs varnish-apikey_server -f
+else
+  docker exec -it varnish-apikey_server /bin/sh -c "/usr/bin/redis-cli monitor"
+fi

--- a/script/server
+++ b/script/server
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# server: start a server
+#
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ "$1" == "--stop" ] ; then
+  docker-compose -f server.yml down
+else
+  docker-compose -f server.yml up -d
+fi
+

--- a/script/test
+++ b/script/test
@@ -7,7 +7,7 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-if [ "$1" == "vtctrans" ] ; then
+if [ "$1" == "--vtctrans" ] ; then
   docker-compose -f test.yml run vtctrans
 else
   docker-compose -f test.yml run test

--- a/script/test
+++ b/script/test
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Run tests.
+#
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ "$1" == "vtctrans" ] ; then
+  docker-compose -f test.yml run vtctrans
+else
+  docker-compose -f test.yml run test
+fi

--- a/server.yml
+++ b/server.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  server:
+    build: .
+    container_name: varnish-apikey_server
+    volumes:
+      - ./:/home/builder/varnish-apikey
+      - ./vcl/varnish-apikey.vcl:/etc/varnish/varnish-apikey.vcl
+    ports:
+      - 8001:81

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,20 @@
+version: '3.7'
+
+x-test-defaults:
+  &test-defaults
+  build: .
+  container_name: test
+  volumes:
+    - ./:/home/builder/varnish-apikey
+    - ./vcl/varnish-apikey.vcl:/etc/varnish/varnish-apikey.vcl
+  working_dir: /home/builder/varnish-apikey
+  
+
+services:
+  test:
+    <<: *test-defaults
+    command: tests/runner.sh varnishtest tests/*.vtc
+
+  vtctrans:
+    <<: *test-defaults
+    command: tests/runner.sh python ../vtctrans/vtctrans.py tests/*.vtc

--- a/tests/test_blocked_api_key.vtc
+++ b/tests/test_blocked_api_key.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -22,61 +33,57 @@ varnish v1 -vcl {
   }
 
   sub set_up {
-    redis.command("FLUSHDB");
-    redis.execute();
+    db.command("FLUSHDB");
+    db.execute();
     # We have to restrict this api too, so that the api key is used to
     # identify the user
-    redis.command("SET");
-    redis.push("api:testblockedapi:restricted");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testblockedapi:restricted");
+    db.push("1");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testblockedapi:restricted");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testblockedapi:restricted");
+    db.push("1");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testblockedapi:throttled");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testblockedapi:throttled");
+    db.push("1");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testblockedapi:counter:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testblockedapi:counter:time");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testblockedapi:blocked:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testblockedapi:blocked:time");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testblockedapi:default_max");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testblockedapi:default_max");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("key:testapikeyblocked:api:testblockedapi");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("key:testapikeyblocked:api:testblockedapi");
+    db.push("1");
+    db.execute();
 
-    redis.command("SETEX");
-    redis.push("key:testapikeyblocked:api:testblockedapi:blocked");
-    redis.push("60");
-    redis.push("1");
-    redis.execute();
-  }
-
-  sub vcl_init {
-    redis.init("main", "${redis_master_address}", 500, 0, 0, 0, 0, false, 1);
+    db.command("SETEX");
+    db.push("key:testapikeyblocked:api:testblockedapi:blocked");
+    db.push("60");
+    db.push("1");
+    db.execute();
   }
 
   sub vcl_recv {
     call set_up;
     # Validate apikey using apikey library.
     call validate_api;
-    set req.backend = default;
+    set req.backend_hint = default;
   }
 } -start
 

--- a/tests/test_blocked_client_ip.vtc
+++ b/tests/test_blocked_client_ip.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -22,45 +33,41 @@ varnish v1 -vcl {
   }
 
   sub set_up {
-    redis.command("FLUSHDB");
-    redis.execute();
+    db.command("FLUSHDB");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testapiipblocked:throttled");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testapiipblocked:throttled");
+    db.push("1");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testapiipblocked:counter:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testapiipblocked:counter:time");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testapiipblocked:blocked:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testapiipblocked:blocked:time");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testapiipblocked:default_max");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testapiipblocked:default_max");
+    db.push("60");
+    db.execute();
 
-    redis.command("SETEX");
-    redis.push("key:127.0.0.1:api:testapiipblocked:blocked");
-    redis.push("60");
-    redis.push("1");
-    redis.execute();
-  }
-
-  sub vcl_init {
-    redis.init("main", "${redis_master_address}", 500, 0, 0, 0, 0, false, 1);
+    db.command("SETEX");
+    db.push("key:127.0.0.1:api:testapiipblocked:blocked");
+    db.push("60");
+    db.push("1");
+    db.execute();
   }
 
   sub vcl_recv {
     call set_up;
     # Validate apikey using apikey library.
     call validate_api;
-    set req.backend = default;
+    set req.backend_hint = default;
   }
 } -start
 

--- a/tests/test_invalid_api_key.vtc
+++ b/tests/test_invalid_api_key.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -22,29 +33,25 @@ varnish v1 -vcl {
   }
 
   sub set_up {
-    redis.command("FLUSHDB");
-    redis.execute();
+    db.command("FLUSHDB");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testapi:restricted");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testapi:restricted");
+    db.push("1");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("key:testapikey:api:testapi");
-    redis.push("1");
-    redis.execute();
-  }
-
-  sub vcl_init {
-    redis.init("main", "${redis_master_address}", 500, 0, 0, 0, 0, false, 1);
+    db.command("SET");
+    db.push("key:testapikey:api:testapi");
+    db.push("1");
+    db.execute();
   }
 
   sub vcl_recv {
     call set_up;
     # Validate apikey using apikey library.
     call validate_api;
-    set req.backend = default;
+    set req.backend_hint = default;
   }
 } -start
 

--- a/tests/test_no_api_key.vtc
+++ b/tests/test_no_api_key.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -22,24 +33,20 @@ varnish v1 -vcl {
   }
 
   sub set_up {
-    redis.command("FLUSHDB");
-    redis.execute();
+    db.command("FLUSHDB");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testapi:restricted");
-    redis.push("1");
-    redis.execute();
-  }
-
-  sub vcl_init {
-    redis.init("main", "${redis_master_address}", 500, 0, 0, 0, 0, false, 1);
+    db.command("SET");
+    db.push("api:testapi:restricted");
+    db.push("1");
+    db.execute();
   }
 
   sub vcl_recv {
     call set_up;
     # Validate apikey using apikey library.
     call validate_api;
-    set req.backend = default;
+    set req.backend_hint = default;
   }
 } -start
 

--- a/tests/test_throttled_api_key.vtc
+++ b/tests/test_throttled_api_key.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -22,46 +33,42 @@ varnish v1 -vcl {
   }
 
   sub set_up {
-    redis.command("FLUSHDB");
-    redis.execute();
+    db.command("FLUSHDB");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testthrottledapi:throttled");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledapi:throttled");
+    db.push("1");
+    db.execute();
 
     # Set up all the default throttling settings for the api
-    redis.command("SET");
-    redis.push("api:testthrottledapi:counter:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledapi:counter:time");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testthrottledapi:blocked:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledapi:blocked:time");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testthrottledapi:default_max");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledapi:default_max");
+    db.push("60");
+    db.execute();
 
     # Allow this key to access the api, so that it's used instead of the
     # client's IP to identify them
-    redis.command("SET");
-    redis.push("key:testapikeythrottled:api:testthrottledapi");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("key:testapikeythrottled:api:testthrottledapi");
+    db.push("1");
+    db.execute();
 
     # Set a maximum number of calls to test the throttling works
-    redis.command("SET");
-    redis.push("key:testapikeythrottled:ratelimit:testthrottledapi:max");
-    redis.push("1");
-    redis.execute();
-  }
-
-  sub vcl_init {
-    redis.init("main", "${redis_master_address}", 500, 0, 0, 0, 0, false, 1);
+    db.command("SET");
+    db.push("key:testapikeythrottled:ratelimit:testthrottledapi:max");
+    db.push("1");
+    db.execute();
   }
 
   sub vcl_recv {
@@ -72,7 +79,7 @@ varnish v1 -vcl {
     }
     # Validate apikey using apikey library.
     call validate_api;
-    set req.backend = default;
+    set req.backend_hint = default;
   }
 } -start
 

--- a/tests/test_throttled_client_ip.vtc
+++ b/tests/test_throttled_client_ip.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -22,39 +33,35 @@ varnish v1 -vcl {
   }
 
   sub set_up {
-    redis.command("FLUSHDB");
-    redis.execute();
+    db.command("FLUSHDB");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testthrottledbyipapi:throttled");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledbyipapi:throttled");
+    db.push("1");
+    db.execute();
 
     # Set up all the default throttling settings for the api
-    redis.command("SET");
-    redis.push("api:testthrottledbyipapi:counter:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledbyipapi:counter:time");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testthrottledbyipapi:blocked:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledbyipapi:blocked:time");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testthrottledbyipapi:default_max");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledbyipapi:default_max");
+    db.push("60");
+    db.execute();
 
     # Set a maximum number of calls to test the throttling works
-    redis.command("SET");
-    redis.push("key:127.0.0.1:ratelimit:testthrottledbyipapi:max");
-    redis.push("1");
-    redis.execute();
-  }
-
-  sub vcl_init {
-    redis.init("main", "${redis_master_address}", 500, 0, 0, 0, 0, false, 1);
+    db.command("SET");
+    db.push("key:127.0.0.1:ratelimit:testthrottledbyipapi:max");
+    db.push("1");
+    db.execute();
   }
 
   sub vcl_recv {
@@ -65,7 +72,7 @@ varnish v1 -vcl {
     }
     # Validate apikey using apikey library.
     call validate_api;
-    set req.backend = default;
+    set req.backend_hint = default;
   }
 } -start
 

--- a/tests/test_throttled_client_ip_default_max.vtc
+++ b/tests/test_throttled_client_ip_default_max.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -22,35 +33,31 @@ varnish v1 -vcl {
   }
 
   sub set_up {
-    redis.command("FLUSHDB");
-    redis.execute();
+    db.command("FLUSHDB");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testthrottledbyipapidefault:throttled");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledbyipapidefault:throttled");
+    db.push("1");
+    db.execute();
 
     # Set up all the default throttling settings for the api
-    redis.command("SET");
-    redis.push("api:testthrottledbyipapidefault:counter:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledbyipapidefault:counter:time");
+    db.push("60");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testthrottledbyipapidefault:blocked:time");
-    redis.push("60");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testthrottledbyipapidefault:blocked:time");
+    db.push("60");
+    db.execute();
 
     # Set the default_max for the api to 1, but don't set a specific max for
     # the user
-    redis.command("SET");
-    redis.push("api:testthrottledbyipapidefault:default_max");
-    redis.push("1");
-    redis.execute();
-  }
-
-  sub vcl_init {
-    redis.init("main", "${redis_master_address}", 500, 0, 0, 0, 0, false, 1);
+    db.command("SET");
+    db.push("api:testthrottledbyipapidefault:default_max");
+    db.push("1");
+    db.execute();
   }
 
   sub vcl_recv {
@@ -61,7 +68,7 @@ varnish v1 -vcl {
     }
     # Validate apikey using apikey library.
     call validate_api;
-    set req.backend = default;
+    set req.backend_hint = default;
   }
 } -start
 

--- a/tests/test_unprotected_unthrottled.vtc
+++ b/tests/test_unprotected_unthrottled.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -25,7 +36,7 @@ varnish v1 -vcl {
       # Validate apikey using apikey library.
       # Note - the api has't been protected in any way
       call validate_api;
-      set req.backend = default;
+      set req.backend_hint = default;
   }
 } -start
 

--- a/tests/test_unrecognised_api.vtc
+++ b/tests/test_unrecognised_api.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -21,7 +32,7 @@ varnish v1 -vcl {
   sub vcl_recv {
     # Validate apikey using apikey library.
     call validate_api;
-    set req.backend = default;
+    set req.backend_hint = default;
   }
 } -start
 

--- a/tests/test_valid_api_key.vtc
+++ b/tests/test_valid_api_key.vtc
@@ -7,6 +7,17 @@ server s1 {
 
 varnish v1 -vcl {
   import std;
+  import redis;
+
+  sub vcl_init {
+    new db = redis.db(
+        location="${redis_master_address}",
+        type=master,
+        connection_timeout=500,
+        shared_connections=false,
+        max_connections=1);
+  }
+
   include "${pwd}/vcl/varnish-apikey.vcl";
 
   backend default {
@@ -22,29 +33,25 @@ varnish v1 -vcl {
   }
 
   sub set_up {
-    redis.command("FLUSHDB");
-    redis.execute();
+    db.command("FLUSHDB");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("api:testapi:restricted");
-    redis.push("1");
-    redis.execute();
+    db.command("SET");
+    db.push("api:testapi:restricted");
+    db.push("1");
+    db.execute();
 
-    redis.command("SET");
-    redis.push("key:testapikey:api:testapi");
-    redis.push("1");
-    redis.execute();
-  }
-
-  sub vcl_init {
-    redis.init("main", "${redis_master_address}", 500, 0, 0, 0, 0, false, 1);
+    db.command("SET");
+    db.push("key:testapikey:api:testapi");
+    db.push("1");
+    db.execute();
   }
 
   sub vcl_recv {
     # Validate apikey using apikey library.
     call set_up;
     call validate_api;
-    set req.backend = default;
+    set req.backend_hint = default;
   }
 } -start
 


### PR DESCRIPTION
This updates the example VCL to use version 4.0 of the language and ensures compatibility with Varnish 5 and the appropriate libvmod-redis build, all tested against Debian Stretch.

This also includes a Docker-based environment suitable for running the examples and tests.